### PR TITLE
fix: module naming

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     entry_points={
         "errbot.plugins": [
-            "helloworld = helloWorld:HelloWorld",
+            "helloworld = helloworld:HelloWorld",
         ]
     },
 )

--- a/src/helloworld/__init__.py
+++ b/src/helloworld/__init__.py
@@ -1,0 +1,1 @@
+from .helloWorld import HelloWorld


### PR DESCRIPTION
This should address an error in the entrypoint where the module path was incorrect and was unable to be loaded properly.